### PR TITLE
fixed some inits to include proper requires

### DIFF
--- a/lua/ascii/anime/init.lua
+++ b/lua/ascii/anime/init.lua
@@ -1,4 +1,4 @@
-local onepiece = require("onepiece")
+local onepiece = require("ascii.anime.onepiece")
 
 local M = {
     onepiece = onepiece

--- a/lua/ascii/gaming/init.lua
+++ b/lua/ascii/gaming/init.lua
@@ -1,5 +1,6 @@
 local pacman = require("ascii.gaming.pacman")
 local undertale = require("ascii.gaming.undertale")
+local doom = require("ascii.gaming.doom")
 
 local M = {
 	pacman = pacman,

--- a/lua/ascii/misc/init.lua
+++ b/lua/ascii/misc/init.lua
@@ -1,5 +1,6 @@
 local skulls = require("ascii.misc.skulls")
 local krakens = require("ascii.misc.krakens")
+local hydra = require("ascii.misc.hydra")
 
 local M = {
 	skulls = skulls,


### PR DESCRIPTION
Recent addition of some art breaks ascii.nvim because of improper loading of required files
anime/init.lua has improper require("onepiece.lua") instead of ("ascii.anime.onepiece") which breaks loading the plugin. 

Changed two init.lua files to include ' local doom = require("ascii.gaming.doom") ' and ' local hydra = require("ascii.misc.hydra")